### PR TITLE
corregido error faltaba un parentesis

### DIFF
--- a/Proyecto-Dwamana/js/actividades.js
+++ b/Proyecto-Dwamana/js/actividades.js
@@ -9,6 +9,7 @@
         		effect: "explode",
        		 	delay: 250
       		}
+});
 }
 
 /**


### PR DESCRIPTION
Había dejado mal cerrado un paréntesis en el tooltip y provocaba que no se visualizara la seccion Actividades